### PR TITLE
Cwire Bid Adapter support domainId and deprecate placementId

### DIFF
--- a/modules/cwireBidAdapter.js
+++ b/modules/cwireBidAdapter.js
@@ -151,14 +151,18 @@ export const spec = {
    * @return boolean True if this is a valid bid, and false otherwise.
    */
   isBidRequestValid: function (bid) {
-    if (!bid.params?.placementId || !isNumber(bid.params.placementId)) {
-      logError('placementId not provided or not a number');
-      return false;
-    }
+    if (!bid.params?.domainId || !isNumber(bid.params.domainId)) {
+      logError('domainId not provided or not a number');
+      if (!bid.params?.placementId || !isNumber(bid.params.placementId)) {
+        logError('placementId not provided or not a number');
+        return false;
+      }
 
-    if (!bid.params?.pageId || !isNumber(bid.params.pageId)) {
-      logError('pageId not provided or not a number');
-      return false;
+      if (!bid.params?.pageId || !isNumber(bid.params.pageId)) {
+        logError('pageId not provided or not a number');
+        return false;
+      }
+      return true;
     }
     return true;
   },
@@ -176,8 +180,8 @@ export const spec = {
     // process bid requests
     let processed = validBidRequests
       .map(bid => slotDimensions(bid))
-      // Flattens the pageId and placement Id for backwards compatibility.
-      .map((bid) => ({...bid, pageId: bid.params?.pageId, placementId: bid.params?.placementId}));
+      // Flattens the pageId, domainId and placement Id for backwards compatibility.
+      .map((bid) => ({...bid, pageId: bid.params?.pageId, domainId: bid.params?.domainId, placementId: bid.params?.placementId}));
 
     const extensions = getCwExtension();
     const payload = {

--- a/modules/cwireBidAdapter.md
+++ b/modules/cwireBidAdapter.md
@@ -14,14 +14,15 @@ Prebid.js Adapter for C-Wire.
 
 Below, the list of C-WIRE params and where they can be set.
 
-| Param name  | URL parameter | AdUnit config |   Type   |   Required    |
-|-------------|:-------------:|:-------------:|:--------:|:-------------:|
-| pageId      |               |       x       |  number  |      YES      |
-| placementId |               |       x       |  number  |      YES      |
-| cwgroups    |       x       |               |  string  |      NO       |
-| cwcreative  |       x       |               |  string  |      NO       |
-| cwdebug     |       x       |               | boolean  |      NO       |
-| cwfeatures  |       x       |               |  string  |      NO       |
+| Param name  | URL parameter | AdUnit config |   Type   | Required |
+|-------------|:-------------:|:-------------:|:--------:|:--------:|
+| pageId      |               |       x       |  number  |    NO    |
+| domainId    |               |       x       |  number  |   YES    |
+| placementId |               |       x       |  number  |    NO    |
+| cwgroups    |       x       |               |  string  |    NO    |
+| cwcreative  |       x       |               |  string  |    NO    |
+| cwdebug     |       x       |               | boolean  |    NO    |
+| cwfeatures  |       x       |               |  string  |    NO    |
 
 
 ### adUnit configuration
@@ -38,11 +39,29 @@ var adUnits = [
         }
       },
       params: {
-        pageId: 1422,                 // required - number
-        placementId: 2211521,         // required - number
+        domainId: 1422,               // required - number
+        placementId: 2211521,         // optional - number
       }
     }]
   }
+];
+// old version for the compatibility
+var adUnits = [
+    {
+        code: 'target_div_id', // REQUIRED
+        bids: [{
+            bidder: 'cwire',
+            mediaTypes: {
+                banner: {
+                    sizes: [[400, 600]],
+                }
+            },
+            params: {
+                pageId: 1422,               // required - number
+                placementId: 2211521,       // required - number
+            }
+        }]
+    }
 ];
 ```
 


### PR DESCRIPTION
## Type of change
- [x] Updated bidder adapter

## Description of change

Updating our prebid adapter to include domainId and make placementId optional (deprecated), while leaving the old params for compatibility purposes.

